### PR TITLE
Add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# DEPRECATED: Use [elm-community/string-extra](http://package.elm-lang.org/packages/elm-community/string-extra/latest) instead
+
 ## Additional String functions for Elm
 
 [![Build Status](https://travis-ci.org/lorenzo/elm-string-addons.svg?branch=master)](https://travis-ci.org/lorenzo/elm-string-addons)


### PR DESCRIPTION
According to the docs at http://package.elm-lang.org/packages/elm-community/string-extra/latest, it looks like this package is meant to be superseded by by elm-community/string-extra.  If that's correct, then I think adding this note to the README would be helpful.